### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files in this repo
+* @zoli-kasa


### PR DESCRIPTION
Adds a CODEOWNERS file setting @zoli-kasa as the default owner for this repo.

Part of a cross-repo effort to ensure every repository has code ownership defined.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata only; no application code, runtime behavior, or security logic is modified.
> 
> **Overview**
> Adds a **`.github/CODEOWNERS`** file that assigns **`@zoli-kasa`** as the default owner for all paths (`*`), so GitHub can automatically request their review on pull requests across the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55a4f8a94cd3a868088f0af8794e7f55eb4ed4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->